### PR TITLE
Fixed 5 issues of type: PYTHON_E225 throughout 2 files in repo.

### DIFF
--- a/arduino/Escher/tools/graphics.py
+++ b/arduino/Escher/tools/graphics.py
@@ -513,7 +513,7 @@ class GraphicsObject:
         if canvas and not canvas.isClosed():
             trans = canvas.trans
             if trans:
-                x = dx/ trans.xscale 
+                x = dx / trans.xscale 
                 y = -dy / trans.yscale
             else:
                 x = dx
@@ -866,7 +866,7 @@ class Entry(GraphicsObject):
             raise GraphicsError(BAD_OPTION)
 
     def setTextColor(self, color):
-        self.color=color
+        self.color = color
         if self.entry:
             self.entry.config(fg=color)
 
@@ -942,7 +942,7 @@ class Image(GraphicsObject):
         """Sets pixel (x,y) to the given color
         
         """
-        self.img.put("{" + color +"}", (x, y))
+        self.img.put("{" + color + "}", (x, y))
         
 
     def save(self, filename):

--- a/pi/snake/snake.py
+++ b/pi/snake/snake.py
@@ -19,10 +19,10 @@ def randcolor():
   b = random.randint(0, 255)
   return b
 
-b=randcolor()
+b = randcolor()
 while y <= 15:
   while x <= 15:
-    b =randcolor()
+    b = randcolor()
     unicorn.set_pixel(x, y, 0, 0, b)
     unicorn.show()
     x = x+1


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.